### PR TITLE
Don't render nav links if there are not pages

### DIFF
--- a/src/app/components/ComponentsUtils.js
+++ b/src/app/components/ComponentsUtils.js
@@ -42,7 +42,7 @@ const generateMenuLinks = (config, exampleType, pathRoot) => (
     const componentPath = componentKey.path;
     const examples = componentKey[`${exampleType}`];
 
-    if (!componentPath) {
+    if (!componentPath || (!examples && !componentKey.component)) {
       return undefined;
     }
     let path = `${pathRoot}${componentPath}`;


### PR DESCRIPTION
### Summary
When opening up navigation for a single component, I accidentally opened up the menu link generation to create links for everything even if there's not content. 