### PR TITLE
Add ident key to Postcss-loader

### DIFF
--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -51,6 +51,7 @@ const defaultWebpackConfig = {
         }, {
           loader: 'postcss-loader',
           options: {
+            ident: 'postcss',
             plugins() {
               return [
                 Autoprefixer({


### PR DESCRIPTION
### Summary
There are issues in building site using terra-dev-site due to the terra-button-group with the following error:
<details>
<summary> Error Output: </summary>

![screen shot 2018-02-27 at 5 05 05 pm](https://user-images.githubusercontent.com/14099737/36760470-9e9bca9c-1be0-11e8-8130-11c0817f19d4.png)


</details>


Adding an ident key resolves this issue, as well as Closes #35.
