### PR TITLE
Update ConfigureUtilities.jsx

### DIFF
--- a/src/app/ConfigureUtilities.jsx
+++ b/src/app/ConfigureUtilities.jsx
@@ -53,7 +53,7 @@ const updateSelectedItem = (parentMenuItem, selectedItem) => {
 class ConfigureUtilties {
 
   static generateInitialUtiltiesConfig(appConfig) {
-    const hasThemes = appConfig.themes && appConfig.themes.length > 0;
+    const hasThemes = appConfig.themes && Object.keys(appConfig.themes).length > 0;
     const hasLocals = appConfig.locales && appConfig.locales.length > 0;
 
     if (!(hasThemes || hasLocals || appConfig.bidirectional)) {
@@ -63,7 +63,7 @@ class ConfigureUtilties {
     const rootMenuChildKeys = {};
 
     if (hasThemes) {
-      rootMenuChildKeys.Theme = generateItemConfig(appConfig.defaultTheme, appConfig.themes, 'Theme');
+      rootMenuChildKeys.Theme = generateItemConfig(appConfig.defaultTheme, Object.keys(appConfig.themes), 'Theme');
     }
 
     if (hasLocals) {


### PR DESCRIPTION
### Summary
Resolves #67 

This update converts the `appConfig.themes` object keys to an array in 2 places. 
One where we check if `appConfig.themes` is empty and one where we pass `appConfig.themes` to the [generateItemConfig function](https://github.com/cerner/terra-dev-site/blob/master/src/app/ConfigureUtilities.jsx#L4) which expects an array passed to it for its items.