### PR TITLE
No-longer load config dynamically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changes
+* Load config into index.jsx statically instead of dynamically.
 
 0.4.1 - (April 11, 2018)
 ----------

--- a/src/Index.jsx
+++ b/src/Index.jsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom';
 import { HashRouter as Router } from 'react-router-dom';
 import { Provider } from 'xfc';
 import Image from 'terra-image';
+// This line will be resolved by webpack
+// eslint-disable-next-line import/no-unresolved
+import customSiteConfig from 'site.config';
 
 import App from './app/App';
 import defaultSiteConfig from './config/site.config';
@@ -22,18 +25,8 @@ class Site extends React.Component {
     this.state = { siteConfig: defaultSiteConfig };
   }
 
-  componentDidMount() {
-    // SITE_CONFIG_PATH is a global variable defined at runtime by the DefinePlugin within the scripts/start-terra-dev-site/site.webpack.config.
-    // eslint-disable-next-line no-undef
-    if (SITE_CONFIG_PATH !== undefined) {
-      // eslint-disable-next-line no-undef
-      import(SITE_CONFIG_PATH)
-        .then(module => this.setState({ siteConfig: module.default }));
-    }
-  }
-
   render() {
-    const siteConfig = Object.assign({}, defaultSiteConfig, this.state.siteConfig);
+    const siteConfig = Object.assign({}, defaultSiteConfig, customSiteConfig);
     siteConfig.appConfig = Object.assign({}, defaultSiteConfig.appConfig, siteConfig.appConfig);
     const { appConfig, componentConfig } = siteConfig;
 

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -21,10 +21,8 @@ const rootPath = processPath.includes('packages') ? processPath.split('packages'
 
 aggregateTranslations({ baseDirectory: rootPath });
 
-/* Get the site configuration to define as SITE_CONFIG in the DefinePlugin */
-let siteConfigPath = path.resolve(path.join(rootPath, 'site.config.js'));
-// eslint-disable-next-line import/no-dynamic-require
-siteConfigPath = isFile(siteConfigPath) ? siteConfigPath : './config/site.config';
+const customSiteConfigPath = path.join(rootPath, 'site.config.js');
+const devSiteConfigPath = isFile(customSiteConfigPath) ? rootPath : path.join('src', 'config');
 
 const defaultWebpackConfig = {
   entry: {
@@ -95,9 +93,6 @@ const defaultWebpackConfig = {
       template: path.join(__dirname, '..', 'index.html'),
       chunks: ['raf', 'babel-polyfill', 'terra-dev-site'],
     }),
-    new webpack.DefinePlugin({
-      SITE_CONFIG_PATH: JSON.stringify(siteConfigPath),
-    }),
     new PostCSSAssetsPlugin({
       test: /\.css$/,
       log: false,
@@ -109,7 +104,7 @@ const defaultWebpackConfig = {
   ],
   resolve: {
     extensions: ['.js', '.jsx'],
-    modules: [path.resolve(rootPath, 'aggregated-translations'), 'node_modules'],
+    modules: [devSiteConfigPath, path.resolve(rootPath, 'aggregated-translations'), 'node_modules'],
 
     // See https://github.com/facebook/react/issues/8026
     alias: {


### PR DESCRIPTION
### Summary
Use webpack fallbacks to provide a static custom config.

@cerner/terra

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
