### PR TITLE
Enable source maps in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Prod webpack config produces source maps
 
 1.2.2 - (June 12, 2018)
 ----------

--- a/config/webpack/terra-dev-site.webpack.config.js
+++ b/config/webpack/terra-dev-site.webpack.config.js
@@ -94,6 +94,7 @@ const devSiteConfig = (env = {}, argv = {}) => {
       modules: [devSiteConfigPath],
       alias,
     },
+    ...(production) && { devtool: 'source-map' },
   };
 };
 

--- a/tests/config/webpack/webpack.config.test.js
+++ b/tests/config/webpack/webpack.config.test.js
@@ -1,0 +1,69 @@
+const webpackConfig = require('../../../config/webpack/webpack.config');
+
+describe('webpack config', () => {
+  it('generates wepack config for dev', () => {
+    const config = webpackConfig();
+    const processPath = process.cwd();
+    expect(config).toEqual(expect.objectContaining({
+      entry: expect.objectContaining({
+        'terra-dev-site': `${processPath}/lib/Index`,
+      }),
+      resolve: expect.objectContaining({
+        modules: expect.arrayContaining([
+          `${processPath}/dev-site-config`,
+        ]),
+        alias: expect.objectContaining({
+          react: `${processPath}/node_modules/react`,
+          'react-intl': `${processPath}/node_modules/react-intl`,
+          'react-dom': `${processPath}/node_modules/react-dom`,
+          'terra-dev-site/lib': `${processPath}/src`,
+          'terra-dev-site': `${processPath}`,
+        }),
+      }),
+      plugins: expect.arrayContaining([
+        expect.objectContaining({
+          options: expect.objectContaining({
+            title: 'Terra Dev Site',
+            template: `${processPath}/lib/index.html`,
+            lang: 'en',
+            dir: 'ltr',
+            favicon: `${processPath}/terra-favicon/32px/favicon.ico`,
+          }),
+        }),
+      ]),
+    }));
+  });
+
+  it('generates wepack config for prod', () => {
+    const config = webpackConfig(undefined, { p: true });
+    const processPath = process.cwd();
+    expect(config).toEqual(expect.objectContaining({
+      entry: expect.objectContaining({
+        'terra-dev-site': `${processPath}/lib/Index`,
+      }),
+      resolve: expect.objectContaining({
+        modules: expect.arrayContaining([
+          `${processPath}/dev-site-config`,
+        ]),
+        alias: expect.objectContaining({
+          react: `${processPath}/node_modules/react`,
+          'react-intl': `${processPath}/node_modules/react-intl`,
+          'react-dom': `${processPath}/node_modules/react-dom`,
+          'terra-dev-site': `${processPath}`,
+        }),
+      }),
+      plugins: expect.arrayContaining([
+        expect.objectContaining({
+          options: expect.objectContaining({
+            title: 'Terra Dev Site',
+            template: `${processPath}/lib/index.html`,
+            lang: 'en',
+            dir: 'ltr',
+            favicon: `${processPath}/terra-favicon/32px/favicon.ico`,
+          }),
+        }),
+      ]),
+      devtool: 'source-map',
+    }));
+  });
+});


### PR DESCRIPTION
### Summary
Enabling source maps in prod.

### Additional Details
And add some tests for webpack config.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
