### PR TITLE
Updating generatePagesConfig to allow wdio and nightwatch tests to run on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Changing Page config to use POSIX path separator instead of Windows
 
 1.3.0 - (June 15, 2018)
 ----------

--- a/scripts/generate-app-config/generatePagesConfig.js
+++ b/scripts/generate-app-config/generatePagesConfig.js
@@ -40,7 +40,7 @@ const getRoutes = (directory, type, fileName, entryPoint) => {
   // Remove the directories up to the entry point.
   const modifiedDirectory = directory.replace(entryPoint, '');
 
-  let routes = modifiedDirectory.split(path.sep);
+  let routes = modifiedDirectory.split('/');
 
   // Note: spliting on seperator results in the first array element to be '' so we shift to get rid of it.
   routes.shift();


### PR DESCRIPTION
### Summary
Replacing a path.sep with the POSIX seperator, since all the paths are being generated in POSIX.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
