### PR TITLE
Support repository field not existing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Cerner Corporation
 - Cory McDonald [@corymcdonald]
 - Nathan Faltermeier [@Blackop778]
 - Ben Boersma [@BenBoersma]
+- Noah Benham [@noahbenham]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -15,3 +16,5 @@ Cerner Corporation
 [@corymcdonald]: https://github.com/corymcdonald
 [@Blackop778]: https://github.com/Blackop778
 [@BenBoersma]: https://github.com/BenBoersma
+[@noahbenham]: https://github.com/NoahBenham
+

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -118,7 +118,7 @@ const siteConfig = {
      *       gitHubUrl: 'https://github.com/cerner',
      *     },
      */
-    ...(npmPackage.repository.url) && {
+    ...(npmPackage.repository && npmPackage.repository.url) && {
       extensions: {
         gitHubUrl: npmPackage.repository.url.replace('git+', ''),
       },


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
I'm attempting to use [wdio runner](https://github.com/cerner/terra-toolkit/tree/master/scripts/wdio#wdio-runner) and cannot without adding a `repository` field in `package.json`.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
