### PR TITLE
Fix Page Generation Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+###
+* Fix page generation logic when source or dist options are not provided when using the generatePages configuration option
 
 2.6.0 - (October 8, 2018)
 ----------

--- a/scripts/generate-app-config/generatePagesConfig.js
+++ b/scripts/generate-app-config/generatePagesConfig.js
@@ -144,7 +144,10 @@ const generatePagesConfig = (siteConfig, production, verbose) => {
     root, source, dist, entryPoint,
   }) => {
     const rootPath = root.replace(/[\\]/g, '/');
-    const sourceDir = ((!production && hotReloading) ? `${source}/` : `${dist}/`) || '';
+    let sourceDir = '';
+    if (source && dist) {
+      sourceDir = (!production && hotReloading) ? `${source}/` : `${dist}/`;
+    }
     acc.push({
       pattern: `${rootPath}/${sourceDir}${entryPoint}/**/*.{${types},}.{jsx,js,md}`,
       entryPoint: `${rootPath}/${sourceDir}${entryPoint}`,

--- a/scripts/generate-app-config/generatePagesConfig.js
+++ b/scripts/generate-app-config/generatePagesConfig.js
@@ -145,8 +145,8 @@ const generatePagesConfig = (siteConfig, production, verbose) => {
   }) => {
     const rootPath = root.replace(/[\\]/g, '/');
     let sourceDir = '';
-    if (source && dist) {
-      sourceDir = (!production && hotReloading) ? `${source}/` : `${dist}/`;
+    if (dist) {
+      sourceDir = (!production && hotReloading && source) ? `${source}/` : `${dist}/`;
     }
     acc.push({
       pattern: `${rootPath}/${sourceDir}${entryPoint}/**/*.{${types},}.{jsx,js,md}`,


### PR DESCRIPTION
### Summary
Before the following always evaluated to either `${source}/` or `${dist}/`. If source or dist was not provided in the config, it results in `undefined/`. 

```const sourceDir = ((!production && hotReloading) ? `${source}/` : `${dist}/`) || '';```

(finding my own bugs...) 🤦‍♀️ 