### PR TITLE
Update Rendered Routes to use its Route Props

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -57,13 +57,6 @@ const propTypes = {
    */
   // eslint-disable-next-line react/forbid-prop-types
   themes: PropTypes.object,
-  /**
-   * Injected by react-routed: represent where the app is now, where you want it to go,
-   * or even where it was.
-   */
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-  }),
 };
 
 const defaultProps = {
@@ -73,7 +66,6 @@ const defaultProps = {
   navigationItems: undefined,
   extensions: undefined,
   utilityConfig: undefined,
-  location: undefined,
 };
 
 class App extends React.Component {
@@ -122,7 +114,7 @@ class App extends React.Component {
 
   render() {
     const {
-      nameConfig, location, routingConfig, navigationItems, indexPath, extensions, themes,
+      nameConfig, routingConfig, navigationItems, indexPath, extensions, themes,
     } = this.props;
     const { theme, locale, dir } = this.state;
     this.utilityConfig = ConfigureUtilities.updateSelectedItems(this.utilityConfig, theme, locale, dir);
@@ -133,7 +125,7 @@ class App extends React.Component {
           <Switch>
             <Route
               path="/raw"
-              render={() => RawRoute(routingConfig, location, '/raw')}
+              render={routeProps => RawRoute(routingConfig, routeProps)}
             />
             <Route
               render={() => (

--- a/src/app/components/RawRoute.jsx
+++ b/src/app/components/RawRoute.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { matchPath } from 'react-router-dom';
 
-const RawRoute = (routingConfig, location, prefix) => {
+const RawRoute = (routingConfig, { location, match }) => {
   const routes = Object.keys(routingConfig.content).sort().reverse();
-  const nonRawPath = location.pathname.substring(prefix.length);
+  const nonRawPath = location.pathname.substring(match.path.length);
 
   const route = routes.find(routeToMatch => matchPath(nonRawPath, routeToMatch));
 


### PR DESCRIPTION
### Summary
React-router's `<Route>` component will pass [`route-props`](https://reacttraining.com/react-router/web/api/Route/route-props) to all three of it's render methods. The route-props are: `match`, `location`, and `history`.