### PR TITLE
[terra-dev-site] Fix for console error when ESC key is pressed in the search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 * Updated fs-extra dependency to ^8.0.0
 * Updated babel-eslint dev-dependency to ^10.0.1
 
+### Fixed
+* Fixed the console error which occured when ESC was pressed in the search filter.
+
 5.0.0 - (May 31, 2019)
 ----------
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Cerner Corporation
 - Cody Price [@dev-cprice]
 - Mike Hemesath [@mhemesath]
 - Adam Parker [@amichaelparker]
+- Avinash Gupta [@avinashg1994]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -27,3 +28,4 @@ Cerner Corporation
 [@dev-cprice]: https://github.com/dev-cprice
 [@mhemesath]: https://github.com/mhemesath
 [@amichaelparker]: https://github.com/amichaelparker
+[@avinashg1994]: https://github.com/avinashg1994

--- a/src/app/components/DevSiteRoutingMenu.jsx
+++ b/src/app/components/DevSiteRoutingMenu.jsx
@@ -136,8 +136,7 @@ class DevSiteRoutingMenu extends Component {
     return Promise.resolve().then(() => routeFunc());
   }
 
-  handleFilter(event) {
-    const filterText = event.target.value;
+  handleFilter(event, filterText) {
     const { menuItems: initialMenuItems } = this.props;
 
     const filter = searchFilter(filterText);


### PR DESCRIPTION
### Summary
Fixed the console error when ESC key is pressed in the search filter by using the SearchField text as the filter text.

### Additional Details
The issue was reproducible in all the browser. So verified the fix with all of them.

Fixes #172