### PR TITLE
Prepare for hash links, console log error boundary, fix missing keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Changelog
 Unreleased
 ----------
 ### Fixed
-* Add back github icon for old site passivity
-
-### Added
-* Heading anchors for md files included direclty. This does not include markdown pulled in through terra-doc-template.
+* Add back github icon for old site passivity.
+* Scroll to location if an anchor is present.
+* Log error boundry error to console.
+* Add missing keys to status views.
 
 6.0.0 - (July 30, 2019)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Add back github icon for old site passivity
 
+### Added
+* Heading anchors for md files included direclty. This does not include markdown pulled in through terra-doc-template.
+
 6.0.0 - (July 30, 2019)
 ----------
 ### Breaking

--- a/src/navigation/_DevSiteNavigation.jsx
+++ b/src/navigation/_DevSiteNavigation.jsx
@@ -84,17 +84,6 @@ class DevSiteNavigation extends React.Component {
     };
   }
 
-  static scrollToALink(location) {
-    if (!location || location.length < 2) {
-      return;
-    }
-    const elementName = location.hash.slice(1);
-    const element = document.getElementsByName(elementName);
-    if (element[0]) {
-      element[0].scrollIntoView();
-    }
-  }
-
   static launchExtension(key, disclosureManager, { Component, props = {}, size = 'large' }) {
     disclosureManager.disclose({
       preferredType: 'modal',
@@ -116,11 +105,6 @@ class DevSiteNavigation extends React.Component {
     this.handleItemSelection = this.handleItemSelection.bind(this);
     this.handleExtensionSelection = this.handleExtensionSelection.bind(this);
     this.handleSettingsSelection = this.handleSettingsSelection.bind(this);
-  }
-
-  componentDidMount() {
-    const { location } = this.props;
-    DevSiteNavigation.scrollToALink(location);
   }
 
   getExtensionItems() {

--- a/src/static-pages/_NotFoundPage.jsx
+++ b/src/static-pages/_NotFoundPage.jsx
@@ -25,10 +25,12 @@ const NotFoundPage = ({ history, homePath }) => (
       buttonAttrs={[
         {
           text: 'Go Back',
+          key: 'Go Back',
           onClick: () => { history.goBack(); },
         },
         {
           text: 'Home',
+          key: 'Home',
           onClick: () => { history.replace(homePath); },
         },
       ]}

--- a/src/wrappers/_ContentErrorBoundary.jsx
+++ b/src/wrappers/_ContentErrorBoundary.jsx
@@ -22,6 +22,8 @@ class ContentErrorBoundary extends React.Component {
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
+    // eslint-disable-next-line no-console
+    console.error(error);
     return { hasError: true, error };
   }
 

--- a/src/wrappers/_ContentLoaded.jsx
+++ b/src/wrappers/_ContentLoaded.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
@@ -10,15 +10,27 @@ const propTypes = {
   children: PropTypes.element.isRequired,
 };
 
-const ContentLoaded = ({ children }) => (
-  <div
-    id="site"
-    data-terra-dev-site-content
-    className={cx('dev-site-content')}
-  >
-    {children}
-  </div>
-);
+const ContentLoaded = ({ children }) => {
+  useEffect(() => {
+    if (!window.location || window.location.length < 2) {
+      return;
+    }
+    const elementName = window.location.hash.slice(1);
+    const element = document.getElementsByName(elementName);
+    if (element[0]) {
+      element[0].scrollIntoView();
+    }
+  });
+  return (
+    <div
+      id="site"
+      data-terra-dev-site-content
+      className={cx('dev-site-content')}
+    >
+      {children}
+    </div>
+  );
+};
 
 ContentLoaded.propTypes = propTypes;
 

--- a/src/wrappers/_ErrorPage.jsx
+++ b/src/wrappers/_ErrorPage.jsx
@@ -14,6 +14,7 @@ const ErrorPage = ({ error }) => (
     buttonAttrs={[
       {
         text: 'Refresh',
+        key: 'Refresh',
         onClick: () => { window.location.reload(true); },
       },
     ]}

--- a/src/wrappers/_MarkdownWrapper.jsx
+++ b/src/wrappers/_MarkdownWrapper.jsx
@@ -51,7 +51,7 @@ const MarkdownWrapper = ({ content }) => {
     return (
       <ContentLoaded>
         { markdown
-          ? <div className={cx('markdown')}><TerraMarkdown src={markdown} /></div>
+          ? <div className={cx('markdown')}><TerraMarkdown src={markdown} hasHeadingAnchors /></div>
           : <ErrorPage error="The page failed to load. Refresh the page to try again." />
         }
       </ContentLoaded>

--- a/src/wrappers/_MarkdownWrapper.jsx
+++ b/src/wrappers/_MarkdownWrapper.jsx
@@ -51,7 +51,7 @@ const MarkdownWrapper = ({ content }) => {
     return (
       <ContentLoaded>
         { markdown
-          ? <div className={cx('markdown')}><TerraMarkdown src={markdown} hasHeadingAnchors /></div>
+          ? <div className={cx('markdown')}><TerraMarkdown src={markdown} /></div>
           : <ErrorPage error="The page failed to load. Refresh the page to try again." />
         }
       </ContentLoaded>


### PR DESCRIPTION
### Summary
As it turns out turning on hashlinks in markdown breaks accessibility so we need to fix that before we can turn it on.

This pr Prepares for hashlinks by moving the scroll to to run after code-split content is loaded

### Additional Details
Additionally we  add keys to status view buttons and console log errors caught by the error boundary.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
