### PR TITLE
Remove div to center status view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Add back github icon for old site passivity
 
+### changed
+* Remove div containing status view to center component.
+
 6.0.0 - (July 30, 2019)
 ----------
 ### Breaking

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ Cerner Corporation
 - Adam Parker [@amichaelparker]
 - Avinash Gupta [@avinashg1994]
 - Saket Bajaj [@saket2403]
+- Derek Yu [yuderekyu]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -31,3 +32,4 @@ Cerner Corporation
 [@amichaelparker]: https://github.com/amichaelparker
 [@avinashg1994]: https://github.com/avinashg1994
 [saket2403]: https://github.com/saket2403
+[yuderekyu]: https://github.com/yuderekyu

--- a/src/static-pages/_NotFoundPage.jsx
+++ b/src/static-pages/_NotFoundPage.jsx
@@ -17,23 +17,21 @@ const propTypes = {
 };
 
 const NotFoundPage = ({ history, homePath }) => (
-  <div>
-    <StatusView
-      variant="error"
-      title="404"
-      message="Page not found"
-      buttonAttrs={[
-        {
-          text: 'Go Back',
-          onClick: () => { history.goBack(); },
-        },
-        {
-          text: 'Home',
-          onClick: () => { history.replace(homePath); },
-        },
-      ]}
-    />
-  </div>
+  <StatusView
+    variant="error"
+    title="404"
+    message="Page not found"
+    buttonAttrs={[
+      {
+        text: 'Go Back',
+        onClick: () => { history.goBack(); },
+      },
+      {
+        text: 'Home',
+        onClick: () => { history.replace(homePath); },
+      },
+    ]}
+  />
 );
 
 NotFoundPage.propTypes = propTypes;


### PR DESCRIPTION
### Summary
Remove div to center status view. 

Div does not have 100% height, so status view renders at the top of the page.