### PR TITLE
Wrap raw in main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 
 ### changed
 * Remove div containing status view to center component.
+* Raw routes are wrapped in main.
 
 6.0.0 - (July 30, 2019)
 ----------

--- a/src/raw/_Raw.jsx
+++ b/src/raw/_Raw.jsx
@@ -34,8 +34,12 @@ const Raw = ({ indexPath, contentConfig, location }) => {
   const route = routes.find(routeToMatch => matchPath(nonRawPath, routeToMatch));
 
   if (route) {
-    const routeData = flattenedRouteConfig[route].component.default;
-    return React.createElement(routeData.componentClass, routeData.props);
+    const { componentClass: ComponentClass, props } = flattenedRouteConfig[route].component.default;
+    return (
+      <main>
+        <ComponentClass {...props} />
+      </main>
+    );
   }
 
   return <NotFoundPage homePath={indexPath} />;


### PR DESCRIPTION
### Summary
Wrap raw routes in a main element to prevent un needed a11y errors for components intended to be embedded.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
