### PR TITLE
[keycode-js]Keycode-Js update to v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated Object.assign syntax to Object spread syntax
-
+* Updated `keycode-js` to `V2.0.1`
 6.1.1 - (August 13, 2019)
 ----------
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ Cerner Corporation
 - Avinash Gupta [@avinashg1994]
 - Saket Bajaj [@saket2403]
 - Derek Yu [yuderekyu]
+- Lokesh P[@lokesh-0813 ]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -33,3 +34,4 @@ Cerner Corporation
 [@avinashg1994]: https://github.com/avinashg1994
 [saket2403]: https://github.com/saket2403
 [yuderekyu]: https://github.com/yuderekyu
+[@lokesh-0813]: https://github.com/lokesh-0813

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "fuse.js": "^3.4.5",
     "glob": "^7.1.1",
     "html-webpack-plugin": "^3.1.0",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.kebabcase": "^4.1.1",
     "lodash.startcase": "^4.4.0",


### PR DESCRIPTION
### Summary
Updated `keycode-js` from `v1.0.4` to `v2.0.1`

### Additional Details
Throws warning for multiple versions. Will be fixed once terra-framework is updated  to `keycode-js v2.0.1`


