### PR TITLE
Fix relative urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Fixed
+* Deployed site relative urls not appropriately generated.
+
 6.5.0 - (October 8, 2019)
 ----------
 ### Changed

--- a/config/webpack/plugin/SetupPlugin.js
+++ b/config/webpack/plugin/SetupPlugin.js
@@ -21,7 +21,8 @@ const mdxOptions = (publicPath) => ({
     [rehypeUrl, (url) => {
       // Re-write relative urls to include public path.
       if (!url.protocol && url.pathname && url.pathname.startsWith('/') && publicPath.length > 1) {
-        return `${publicPath}${url.pathname}`;
+        // Remove the first slash from the url.pathname because publicPath always ends with one.
+        return `${publicPath}${url.pathname.slice(1)}`;
       }
       return url.href;
     }],


### PR DESCRIPTION
### Summary
This page ([link](https://engineering.cerner.com/terra-dev-site/test/terra-dev-site/relative-link)) should correctly redirect to: 
https://engineering.cerner.com/terra-dev-site/test/terra-dev-site/md

but it has too many forward slashes when generated, like this: 

https://engineering.cerner.com/terra-dev-site//test/terra-dev-site/md

### Additional Details
I can't write tests for this because of how the site gets deployed for testing vs how it gets deployed to gh-pages. I, in fact, already have tests for this page which works, but just not in this instance.

@cerner/terra

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
