### PR TITLE
Fix hot reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 ### Fixed
 * Deployed site relative urls not appropriately generated.
 * Use the static renderDescription method in example template component.
+* Hot reloading did not function correctly when resolving a relatively aliased path.
 
 6.5.0 - (October 8, 2019)
 ----------

--- a/config/webpack/plugin/resolve/DirectorySwitcherPlugin.js
+++ b/config/webpack/plugin/resolve/DirectorySwitcherPlugin.js
@@ -20,6 +20,8 @@ class DirectorySwitcherPlugin {
       )),
       [],
     );
+    // Temporary https://github.com/webpack/enhanced-resolve/issues/200 or prop driven or just hard coded ¯\_(ツ)_/¯
+    this.extensions = ['.js'];
   }
 
   apply(resolver) {
@@ -31,7 +33,15 @@ class DirectorySwitcherPlugin {
           const index = this.dirs.findIndex(pairs => request.path.startsWith(pairs.distribution));
           if (index >= 0) {
             const { distribution, source } = this.dirs[index];
-            const remainingRequest = request.path.substr(distribution.length);
+            // trim the request
+            let remainingRequest = request.path.substring(distribution.length);
+
+            // if the remaining request extension is one that is resolved, remove it. This allows .js files to resolve to .jsx files
+            const extension = remainingRequest.substring(remainingRequest.lastIndexOf('.'));
+            if (this.extensions.includes(extension)) {
+              remainingRequest = remainingRequest.replace(/\.[^/.]+$/, '');
+            }
+
             const newPathStr = source + remainingRequest;
             const obj = {
               ...request,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "terra-dev-site",
   "version": "6.5.0",
   "description": "Dynamically builds a react-hash-routed site based on site configuration, navigation configuration and component configuration.",
+  "engines": {
+    "node": ">=8.9.2 <11"
+  },
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/tests/jest/config/webpack/plugin/resolve/DirectorySwitcherPlugin.test.js
+++ b/tests/jest/config/webpack/plugin/resolve/DirectorySwitcherPlugin.test.js
@@ -24,5 +24,6 @@ describe('DirectorySwitcherPlugin', () => {
         source: path.join(__dirname, 'packages', 'test', 'src'),
       },
     ]);
+    expect(plugin.extensions).toEqual(['.js']);
   });
 });


### PR DESCRIPTION
### Summary
The directory switcher plugin now removes the extension from files it switches if they are .js files.

The below path is transformed from:
```
"/root/lib/file.js"
```
To:
```
"/root/src/file"
```
Which will resolve to:
```
"/root/src/file.jsx"
```

### Additional Details
I'm not sure how this was working at all, to be honest. We should have been looking for files that didn't exist in the src directory whenever the path had an extension. enhanced resolve must be robust and fall back to the lib file?

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
