### PR TITLE
add inTest navigation config flexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Use inTestNavigation config if the inTest env variable is passed to webpack.
 
 6.12.0 - (January 28, 2020)
 ----------

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -10,6 +10,12 @@ const siteConfig = {
   /* The navigation configuration. */
   navConfig,
 
+  /** This navigation configuration is used if the webpack env variable `inTest` is present.
+   * This setting allows you us flex the nav config to only render test components when testing.
+   * The config options are identical to navigation config options.
+   */
+  inTestNavConfig: undefined,
+
   /* The path to the pages configuration. If this is enabled, the `generatePages` configuration will not be used. */
   pagesConfig: undefined,
 

--- a/config/webpack/plugin/GeneratePlugin.js
+++ b/config/webpack/plugin/GeneratePlugin.js
@@ -52,8 +52,9 @@ const appTitle = (site) => {
  */
 class GeneratePlugin {
   constructor({
-    sites, basename = '',
+    sites, basename = '', inTest = false,
   } = {}) {
+    this.inTest = inTest;
     this.entries = [];
     this.apps = [];
     this.sites = sites.map((site) => {
@@ -104,6 +105,7 @@ class GeneratePlugin {
         apps: this.apps.filter(app => app.path !== prefix),
         basename,
         resolveExtensions: compiler.options.resolve.extensions,
+        inTest: this.inTest,
       });
 
       // generate index html files

--- a/config/webpack/plugin/TerraDevSite.js
+++ b/config/webpack/plugin/TerraDevSite.js
@@ -34,6 +34,7 @@ class TerraDevSite {
   constructor({ env = {}, sites = [] } = {}) {
     // Validate sites.
     validate(sites);
+    this.inTest = env.inTest || false;
     // Sites to generate. Add the default site then load the config if not present
     this.sites = [
       {
@@ -69,6 +70,7 @@ class TerraDevSite {
     new GeneratePlugin({
       sites: this.sites,
       basename,
+      inTest: this.inTest,
     }).apply(compiler);
     new SetupPlugin({
       publicPath,

--- a/scripts/generate-app-config/generateAppConfig.js
+++ b/scripts/generate-app-config/generateAppConfig.js
@@ -91,7 +91,7 @@ const generateAppConfig = ({
     imports,
   );
 
-  const { menuItems, content } = generateContentConfig(siteConfig, generatePagesConfig(siteConfig, resolveExtensions, mode, verbose));
+  const { menuItems, content } = generateContentConfig(siteConfig, generatePagesConfig(siteConfig, navConfig, resolveExtensions, mode, verbose));
   const menuConfigImport = addConfig(
     menuItems,
     'menuItems.js',

--- a/scripts/generate-app-config/generateAppConfig.js
+++ b/scripts/generate-app-config/generateAppConfig.js
@@ -37,15 +37,26 @@ const addConfig = (config, fileName, buildPath, fs, imports) => {
  * } param0
  */
 const generateAppConfig = ({
-  siteConfig, mode, prefix, apps = [], verbose = false, basename, resolveExtensions = [],
+  siteConfig,
+  mode,
+  prefix,
+  apps = [],
+  verbose = false,
+  basename,
+  resolveExtensions = [],
+  inTest = false,
 }) => {
   const imports = new ImportAggregator();
 
   const {
     appConfig,
-    navConfig,
+    inTestNavConfig,
     sideEffectImports,
     placeholderSrc,
+  } = siteConfig;
+
+  let {
+    navConfig,
   } = siteConfig;
 
   const rootPath = path.join(process.cwd(), 'dev-site-config');
@@ -58,6 +69,10 @@ const generateAppConfig = ({
       text: 'Evidence',
       pageTypes: ['evidence'],
     });
+  }
+
+  if (inTest && inTestNavConfig) {
+    navConfig = inTestNavConfig;
   }
 
   const settingsConfig = addConfig(

--- a/scripts/generate-app-config/generatePagesConfig.js
+++ b/scripts/generate-app-config/generatePagesConfig.js
@@ -128,9 +128,9 @@ const sortPageConfig = config => (
 /**
 * Generates the file representing page config, which is in turn consumed by route config.
 */
-const generatePagesConfig = (siteConfig, resolveExtensions, mode, verbose) => {
+const generatePagesConfig = (siteConfig, navConfig, resolveExtensions, mode, verbose) => {
   const {
-    generatePages: generatePagesOptions, pagesConfig, navConfig, hotReloading,
+    generatePages: generatePagesOptions, pagesConfig, hotReloading,
   } = siteConfig;
   // If a pages config is supplied don't do this logic.
   if (pagesConfig) {

--- a/tests/jest/config/webpack/plugin/GeneratePlugin.test.js
+++ b/tests/jest/config/webpack/plugin/GeneratePlugin.test.js
@@ -201,6 +201,7 @@ describe('TerraDevSiteGeneratePlugin', () => {
         title: 'title',
       }],
       basename: 'basename/prefix',
+      inTest: false,
     });
     expect(generateAppConfig).toHaveBeenNthCalledWith(2, {
       siteConfig: {
@@ -218,6 +219,7 @@ describe('TerraDevSiteGeneratePlugin', () => {
         title: 'headline - title - subline',
       }],
       basename: 'basename',
+      inTest: false,
     });
     expect(HtmlWebpackPlugin).toHaveBeenNthCalledWith(1, {
       title: 'title',

--- a/tests/jest/config/webpack/plugin/TerraDevSite.test.js
+++ b/tests/jest/config/webpack/plugin/TerraDevSite.test.js
@@ -10,7 +10,7 @@ const GeneratePlugin = require('../../../../../config/webpack/plugin/GeneratePlu
 const SetupPlugin = require('../../../../../config/webpack/plugin/SetupPlugin');
 const TerraDevSite = require('../../../../../config/webpack/plugin/TerraDevSite');
 
-describe('TerraDevSiteGeneratePlugin', () => {
+describe('TerraDevSitePlugin', () => {
   it('sets up member variables', () => {
     loadSiteConfig.mockReturnValue({ config: 'config', appConfig: { defaultLocale: 'en' } });
     const plug = new TerraDevSite({
@@ -66,6 +66,7 @@ describe('TerraDevSiteGeneratePlugin', () => {
         },
       ],
       basename: '',
+      inTest: false,
     });
     expect(SetupPlugin).toHaveBeenCalledWith({
       publicPath: '/',


### PR DESCRIPTION
### Summary
To try and get the best performance out of terra-dev-site for testing, I am adding the ability to flex the navigation config when the inTest env variable is passed to webpack. This will allow consumers to provide an alternate navigation config to only render the test type components.

### Additional Details
Defaulting an inTest navigation config would be non passive and require a major version bump.
I cannot add tests here for the inTest navigation config because that would break the existing tests for terra-dev-site which test more than just the test tab.

@cerner/terra

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
