### PR TITLE
Consume navigation and overlay from terra-application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 ### Changed
-* Now consume navigation and overlay from terra-application.
+* Now consume navigation and overlay from terra-application. Navigation prompts will now be honored across navigations tabs.
 
 6.13.0 - (February 13, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Now consume navigation and overlay from terra-application.
 
 6.13.0 - (February 13, 2020)
 ----------

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "terra-action-header": "^2.2.0",
     "terra-aggregate-translations": "^1.0.0",
     "terra-application": "^1.0.0",
-    "terra-application-navigation": "^1.0.0",
     "terra-button": "^3.12.0",
     "terra-button-group": "^3.5.0",
     "terra-content-container": "^3.0.0",

--- a/src/ExtendDevSite.jsx
+++ b/src/ExtendDevSite.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 
 import ApplicationBase from 'terra-application';
-import ApplicationNavigation from 'terra-application-navigation';
+import ApplicationNavigation from 'terra-application/lib/application-navigation';
 import ContentContainer from 'terra-content-container';
 
 // This line will be resolved by webpack

--- a/src/TerraDevSite.jsx
+++ b/src/TerraDevSite.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 
 import ApplicationBase from 'terra-application';
-import ApplicationNavigation from 'terra-application-navigation';
+import ApplicationNavigation from 'terra-application/lib/application-navigation';
 
 // This line will be resolved by webpack
 // eslint-disable-next-line import/no-unresolved, import/extensions

--- a/src/navigation/_SecondaryNavigationLayout.jsx
+++ b/src/navigation/_SecondaryNavigationLayout.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { withActiveBreakpoint } from 'terra-application/lib/breakpoints';
-import Overlay from 'terra-overlay';
-import OverlayContainer from 'terra-overlay/lib/OverlayContainer';
+import { ApplicationLoadingOverlayProvider } from 'terra-application/lib/application-loading-overlay';
 import ContentContainer from 'terra-content-container';
 
 import ComponentToolbar from './_ComponentToolbar';
@@ -238,30 +237,21 @@ class SecondaryNavigationLayout extends React.Component {
             onSelect={this.handleCollapsingMenuSelection}
           />
         </div>
-        <OverlayContainer
+        <ContentContainer
           className={cx('content')}
-          overlay={(
-            <Overlay
-              isOpen={isCompact ? compactMenuIsOpen : false}
-              isRelativeToContainer
-              className={cx('overlay')}
-              onRequestClose={this.closeMenu}
+          header={(
+            <ComponentToolbar
+              menuIsVisible={menuIsVisible}
+              onToggle={onToggle}
+              hideDevTools={hideDevTools}
             />
           )}
+          fill
         >
-          <ContentContainer
-            header={(
-              <ComponentToolbar
-                menuIsVisible={menuIsVisible}
-                onToggle={onToggle}
-                hideDevTools={hideDevTools}
-              />
-            )}
-            fill
-          >
+          <ApplicationLoadingOverlayProvider>
             {children}
-          </ContentContainer>
-        </OverlayContainer>
+          </ApplicationLoadingOverlayProvider>
+        </ContentContainer>
       </div>
     );
   }

--- a/src/static-pages/_LoadingPage.jsx
+++ b/src/static-pages/_LoadingPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import LoadingOverlay from 'terra-overlay/lib/LoadingOverlay';
+import ApplicationLoadingOverlay from 'terra-application/lib/application-loading-overlay';
 
 // Wait half a second before showing the loading indicator.
 const LoadingPage = () => {
@@ -15,7 +15,7 @@ const LoadingPage = () => {
     return () => { isActive = false; };
   }, []);
 
-  return <LoadingOverlay message="" isOpen={state.isOpen} isAnimated isRelativeToContainer zIndex="6000" />;
+  return <ApplicationLoadingOverlay isOpen={state.isOpen} />;
 };
 
 export default LoadingPage;


### PR DESCRIPTION
### Summary
With this pr, we're now consuming navigation and overaly from the terra-application package instead of directly. 

### Additional Details
I was unable to use the error page due to having to inject headers into the content on an error.

@cerner/terra

[CONTRIBUTORS.md]: https://github.com/cerner/terra-dev-site/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-dev-site/blob/master/License.md
