### PR TITLE
Add missing plugin imports to getting started config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Changed
 * Now consume navigation and overlay from terra-application. Navigation prompts will now be honored across navigations tabs.
 
+### Added
+* Add plugin imports to getting started example configuration.
+
 6.13.0 - (February 13, 2020)
 ----------
 ### Changed

--- a/src/terra-dev-site/doc/gettingStarted.a.doc.md
+++ b/src/terra-dev-site/doc/gettingStarted.a.doc.md
@@ -36,7 +36,7 @@ Using the TerraDevSite webpack plugin, a static site will be built to the `dev-s
 ```javascript
 const toolkitWebpackConfig = require('terra-toolkit/config/webpack/webpack.config')
 const merge = require('webpack-merge');
-const { TerraDevSite, TerraDevSiteEntrypoints } = require('terra-dev-site');
+const { TerraDevSite, TerraDevSiteEntrypoints, DirectorySwitcherPlugin, LocalPackageAliasPlugin } = require('terra-dev-site');
 
 /**
 * Generates the file representing app name configuration.


### PR DESCRIPTION
### Summary
Add missing imports to getting started example config.
