### PR TITLE
Secondary navigation should not jump when item is visible on screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Secondary nav item should not jump when item is visible.
 
 6.17.0 - (April 23, 2020)
 ----------

--- a/src/navigation/_CollapsingNavigationMenu.jsx
+++ b/src/navigation/_CollapsingNavigationMenu.jsx
@@ -88,9 +88,8 @@ class CollapsingNavigationMenu extends React.Component {
   }
 
   static getDerivedStateFromProps({ menuItems, selectedPath }, state) {
-    const newState = { isNewSelectedPath: false };
+    const newState = {};
     if (state.previousSelectedPath !== selectedPath) {
-      newState.isNewSelectedPath = true;
       newState.openKeys = { ...state.openKeys, ...CollapsingNavigationMenu.openKeysToItem(menuItems[0], selectedPath) };
       newState.previousSelectedPath = selectedPath;
     }
@@ -108,19 +107,11 @@ class CollapsingNavigationMenu extends React.Component {
     this.state = {
       previousSelectedPath: selectedPath,
       openKeys: CollapsingNavigationMenu.openKeysToItem(menuItems[0], selectedPath),
-      isNewSelectedPath: false,
     };
   }
 
   componentDidMount() {
     if (this.selectedItem && this.selectedItem.current) {
-      this.selectedItem.current.scrollIntoView();
-    }
-  }
-
-  componentDidUpdate() {
-    const { isNewSelectedPath } = this.state;
-    if (isNewSelectedPath && this.selectedItem && this.selectedItem.current) {
       this.selectedItem.current.scrollIntoView();
     }
   }

--- a/src/navigation/_CollapsingNavigationMenu.jsx
+++ b/src/navigation/_CollapsingNavigationMenu.jsx
@@ -120,8 +120,9 @@ class CollapsingNavigationMenu extends React.Component {
 
   componentDidUpdate() {
     const { isNewSelectedPath } = this.state;
-    const currentItemPosition = this.selectedItem && this.selectedItem.current ? this.selectedItem.current.getBoundingClientRect().top : null;
-    if (isNewSelectedPath && currentItemPosition > window.screen.height) {
+    const currentItemPosition = this.selectedItem && this.selectedItem.current ? this.selectedItem.current.getBoundingClientRect().bottom : null;
+    const navigationMenuHeight = document.querySelector('#terra-dev-site-nav-menu').getBoundingClientRect().bottom;
+    if (isNewSelectedPath && currentItemPosition > navigationMenuHeight) {
       this.selectedItem.current.scrollIntoView();
     }
   }

--- a/src/navigation/_CollapsingNavigationMenu.jsx
+++ b/src/navigation/_CollapsingNavigationMenu.jsx
@@ -88,8 +88,9 @@ class CollapsingNavigationMenu extends React.Component {
   }
 
   static getDerivedStateFromProps({ menuItems, selectedPath }, state) {
-    const newState = {};
+    const newState = { isNewSelectedPath: false };
     if (state.previousSelectedPath !== selectedPath) {
+      newState.isNewSelectedPath = true;
       newState.openKeys = { ...state.openKeys, ...CollapsingNavigationMenu.openKeysToItem(menuItems[0], selectedPath) };
       newState.previousSelectedPath = selectedPath;
     }
@@ -107,11 +108,20 @@ class CollapsingNavigationMenu extends React.Component {
     this.state = {
       previousSelectedPath: selectedPath,
       openKeys: CollapsingNavigationMenu.openKeysToItem(menuItems[0], selectedPath),
+      isNewSelectedPath: false,
     };
   }
 
   componentDidMount() {
     if (this.selectedItem && this.selectedItem.current) {
+      this.selectedItem.current.scrollIntoView();
+    }
+  }
+
+  componentDidUpdate() {
+    const { isNewSelectedPath } = this.state;
+    const currentItemPosition = this.selectedItem.current ? this.selectedItem.current.getBoundingClientRect().top : null;
+    if (isNewSelectedPath && this.selectedItem && currentItemPosition > window.screen.height) {
       this.selectedItem.current.scrollIntoView();
     }
   }

--- a/src/navigation/_CollapsingNavigationMenu.jsx
+++ b/src/navigation/_CollapsingNavigationMenu.jsx
@@ -120,8 +120,8 @@ class CollapsingNavigationMenu extends React.Component {
 
   componentDidUpdate() {
     const { isNewSelectedPath } = this.state;
-    const currentItemPosition = this.selectedItem.current ? this.selectedItem.current.getBoundingClientRect().top : null;
-    if (isNewSelectedPath && this.selectedItem && currentItemPosition > window.screen.height) {
+    const currentItemPosition = this.selectedItem && this.selectedItem.current ? this.selectedItem.current.getBoundingClientRect().top : null;
+    if (isNewSelectedPath && currentItemPosition > window.screen.height) {
       this.selectedItem.current.scrollIntoView();
     }
   }


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Updated `componentDidUpdate` to compare `currentItemPosition` to ` screenHeight`.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #250 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-si-secondary--p5aabs.herokuapp.com

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
Before 

![Screen-Recording-2020-04-27-at-3 55 38-PM](https://user-images.githubusercontent.com/29273628/80362988-2b8d1580-88a1-11ea-9f80-5705d5cef924.gif)

After

![Screen-Recording-2020-04-27-at-3 56 23-PM](https://user-images.githubusercontent.com/29273628/80362473-57f46200-88a0-11ea-8f16-80a32db0f744.gif)

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
