### PR TITLE
Update Terra Form Select Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated terra-form-select dependency to ^6.0.0
+
+----------
+
 ### Fixed
 * `Secondary Nav Menu` scrolling down when selecting items through spacebar.
 * Fixed some WDIO tests to be more reliable.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ Cerner Corporation
 - Derek Yu [yuderekyu]
 - Lokesh P[@lokesh-0813 ]
 - Gabe Parra [@gabeparra01]
+- Dianna McGinn [@DMcginn]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -37,3 +38,4 @@ Cerner Corporation
 [yuderekyu]: https://github.com/yuderekyu
 [@lokesh-0813]: https://github.com/lokesh-0813
 [@gabeparra01]: https://github.com/gabeparra01
+[@DMcginn]: https://github.com/DMcginn

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "terra-button": "^3.12.0",
     "terra-button-group": "^3.5.0",
     "terra-content-container": "^3.0.0",
-    "terra-form-select": "^5.35.0",
+    "terra-form-select": "^6.0.0",
     "terra-hyperlink": "^2.9.0",
     "terra-icon": "^3.0.0",
     "terra-image": "^3.0.0",


### PR DESCRIPTION
### Summary
Updated the terra-form-select dependency to ^6.0.0 in the package.json file so tha a webpack output warning is not thrown when running terra-core.

Closes #246 

Thank you for contributing to Terra.
@cerner/terra
