### PR TITLE
Reduce locale definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Changed the error in devSitePropsTable.js when it can't find a source to be more informative.
 * Updated eslint-config-terra to @cerner/eslint-config-terra ^4.0.0
+* Removed the locale configuration in favor of using the global `TERRA_AGGREGATED_LOCALES` variable provided by terra-toolkit v5.21.0.
 
 6.22.0 - (June 2, 2020)
 ----------
@@ -14,7 +15,6 @@ Unreleased
 
 ### Changed
 * Updated terra-form-select dependency to ^6.0.0
-* Removed the locale configuration in favor of using the global `TERRA_AGGREGATED_LOCALES` variable provided by terra-toolkit v5.21.0.
 
 6.21.0 - (May 26, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated terra-form-select dependency to ^6.0.0
-* Reduced the number of places locale had to be defined for the client.
+* Removed the locale configuration in favor of using the global `TERRA_AGGREGATED_LOCALES` variable provided by terra-toolkit v5.21.0.
 
 6.21.0 - (May 26, 2020)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated terra-form-select dependency to ^6.0.0
+* Reduced the number of places locale had to be defined for the client.
 
 6.21.0 - (May 26, 2020)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ Cerner Corporation
 - Lokesh P[@lokesh-0813 ]
 - Gabe Parra [@gabeparra01]
 - Dianna McGinn [@DMcginn]
+- Eric McCullough [@EricM96]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@tbiethman]: https://github.com/tbiethman
@@ -39,3 +40,4 @@ Cerner Corporation
 [@lokesh-0813]: https://github.com/lokesh-0813
 [@gabeparra01]: https://github.com/gabeparra01
 [@DMcginn]: https://github.com/DMcginn
+[@EricM96]: https://github.com/EricM96

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -1,4 +1,3 @@
-const i18nSupportedLocales = require('terra-aggregate-translations/config/i18nSupportedLocales');
 const startCase = require('lodash.startcase');
 const fs = require('fs');
 const path = require('path');
@@ -75,8 +74,10 @@ const siteConfig = {
 
     /** The locales to supply Base with, which allows the site to switch
      * between locales. Defaulted to the supported locals list in terra-18n.
+     *
+     * NOTE: This option has been deprecated as of terra-toolkit 5.21.0
      */
-    locales: i18nSupportedLocales,
+    // locales: i18nSupportedLocales,
 
     /* The default locale of the site. 'en' is the default theme. */
     defaultLocale: 'en',

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -1,4 +1,3 @@
-const i18nSupportedLocales = require('terra-aggregate-translations/config/i18nSupportedLocales');
 const startCase = require('lodash.startcase');
 const fs = require('fs');
 const path = require('path');
@@ -77,8 +76,8 @@ const siteConfig = {
      * between locales. Defaulted to the supported locals list in terra-18n.
      *
      * NOTE: This configuration has been deprecated as of terra-toolkit 5.21.0
+     * locales: i18nSupportedLocales,
      */
-    locales: i18nSupportedLocales,
 
     /* The default locale of the site. 'en' is the default theme. */
     defaultLocale: 'en',

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -1,3 +1,4 @@
+const i18nSupportedLocales = require('terra-aggregate-translations/config/i18nSupportedLocales');
 const startCase = require('lodash.startcase');
 const fs = require('fs');
 const path = require('path');
@@ -75,9 +76,9 @@ const siteConfig = {
     /** The locales to supply Base with, which allows the site to switch
      * between locales. Defaulted to the supported locals list in terra-18n.
      *
-     * NOTE: This option has been deprecated as of terra-toolkit 5.21.0
+     * NOTE: This configuration has been deprecated as of terra-toolkit 5.21.0
      */
-    // locales: i18nSupportedLocales,
+    locales: i18nSupportedLocales,
 
     /* The default locale of the site. 'en' is the default theme. */
     defaultLocale: 'en',

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -75,7 +75,7 @@ const siteConfig = {
     /** The locales to supply Base with, which allows the site to switch
      * between locales. Defaulted to the supported locals list in terra-18n.
      *
-     * NOTE: This configuration has been deprecated as of terra-toolkit 5.21.0
+     * NOTE: This configuration has been deprecated as of terra-dev-site 6.23.0
      * locales: i18nSupportedLocales,
      */
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "peerDependencies": {
     "react-dom": "^16.8.5",
     "react": "^16.8.5",
-    "terra-toolkit": "^5.21.0 || ^6.0.0",
+    "terra-toolkit": "^5.18.0 || ^6.0.0",
     "webpack": "^4.28.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "peerDependencies": {
     "react-dom": "^16.8.5",
     "react": "^16.8.5",
-    "terra-toolkit": "^5.18.0 || ^6.0.0",
+    "terra-toolkit": "^5.21.0 || ^6.0.0",
     "webpack": "^4.28.1"
   },
   "devDependencies": {

--- a/scripts/generate-app-config/loadSiteConfig.js
+++ b/scripts/generate-app-config/loadSiteConfig.js
@@ -36,10 +36,13 @@ const resolve = (filePath, defaultConfig) => {
 const loadSiteConfig = (configName = 'site.config.js', defaultPath = '../../config/site/site.config.js') => {
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const defaultConfig = require(defaultPath);
+
+  // If there are site configs, return those, if not, return the defaults
   let projectConfig = defaultConfig;
 
   // Try to find the site config at the default path and then merge it with the defaults.
   const localConfig = resolve(path.resolve(process.cwd(), 'dev-site-config', configName), defaultConfig);
+  // Override defaults with local configs
   if (localConfig) { projectConfig = localConfig; }
 
   // Try to find the locale configs at the default path and override defaults if present.
@@ -47,9 +50,10 @@ const loadSiteConfig = (configName = 'site.config.js', defaultPath = '../../conf
   if (isFile(localLocaleConfig)) {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const config = require(localLocaleConfig);
-    if (config.locales) { projectConfig.locales = config.locales; }
+    // override default locales with local locales
+    if (config.locales) { projectConfig.appConfig.locales = config.locales; }
   }
-  // Return the default config.
+
   return projectConfig;
 };
 

--- a/scripts/generate-app-config/loadSiteConfig.js
+++ b/scripts/generate-app-config/loadSiteConfig.js
@@ -37,24 +37,14 @@ const loadSiteConfig = (configName = 'site.config.js', defaultPath = '../../conf
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const defaultConfig = require(defaultPath);
 
-  // If there are site configs, return those, if not, return the defaults
-  let projectConfig = defaultConfig;
-
   // Try to find the site config at the default path and then merge it with the defaults.
   const localConfig = resolve(path.resolve(process.cwd(), 'dev-site-config', configName), defaultConfig);
-  // Override defaults with local configs
-  if (localConfig) { projectConfig = localConfig; }
-
-  // Try to find the locale configs at the default path and override defaults if present.
-  const localLocaleConfig = path.resolve(process.cwd(), 'terraI18n.config.js');
-  if (isFile(localLocaleConfig)) {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    const config = require(localLocaleConfig);
-    // override default locales with local locales
-    if (config.locales) { projectConfig.appConfig.locales = config.locales; }
+  if (localConfig) {
+    return localConfig;
   }
 
-  return projectConfig;
+  // Return the default config.
+  return defaultConfig;
 };
 
 module.exports = loadSiteConfig;

--- a/scripts/generate-app-config/loadSiteConfig.js
+++ b/scripts/generate-app-config/loadSiteConfig.js
@@ -36,15 +36,21 @@ const resolve = (filePath, defaultConfig) => {
 const loadSiteConfig = (configName = 'site.config.js', defaultPath = '../../config/site/site.config.js') => {
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const defaultConfig = require(defaultPath);
+  let projectConfig = defaultConfig;
 
   // Try to find the site config at the default path and then merge it with the defaults.
   const localConfig = resolve(path.resolve(process.cwd(), 'dev-site-config', configName), defaultConfig);
-  if (localConfig) {
-    return localConfig;
-  }
+  if (localConfig) { projectConfig = localConfig; }
 
+  // Try to find the locale configs at the default path and override defaults if present.
+  const localLocaleConfig = path.resolve(process.cwd(), 'terraI18n.config.js');
+  if (isFile(localLocaleConfig)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const config = require(localLocaleConfig);
+    if (config.locales) { projectConfig.locales = config.locales; }
+  }
   // Return the default config.
-  return defaultConfig;
+  return projectConfig;
 };
 
 module.exports = loadSiteConfig;

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -67,7 +67,7 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
     /* Use default locales or fall back on user configurations configurations.
      * terra-toolkit v5.21.0 provides configurations from terraI18n, so this reduces the number of places users need to define their locales.
      */
-    const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
+    const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : ['en'];
 
     return ({
       ...settingsConfig,

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -23,7 +23,7 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
 
   if (Array.isArray(settingsConfig.locales) && settingsConfig.locales.length !== 0) {
     // eslint-disable-next-line no-console
-    console.warn('Locale configurations are deprecated as of terra-dev-site v6.22.0. You may remove this setting from your configuration files.');
+    console.warn('Locale configurations are deprecated as of terra-dev-site v6.23.0. You may remove this setting from your configuration files.');
   }
 
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -64,8 +64,8 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       }
     };
 
-    /* Use default locales or fall back on user configurations configurations.
-     * terra-toolkit v5.21.0 provides configurations from terraI18n, so this reduces the number of places users need to define their locales.
+    /* Use default locales or fall back on default. terra-toolkit v5.21.0 provides configurations from terraI18n, 
+     * so this reduces the number of places users need to define their locales.
      */
     const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : ['en'];
 

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -64,6 +64,9 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       }
     };
 
+    /* Use default locales or fall back on user configurations configurations.
+     * terra-toolkit v5.21.0 provides configurations from terraI18n, so this reduces the number of places users need to define their locales.
+     */
     const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
 
     return ({

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -1,3 +1,4 @@
+/* global TERRA_AGGREGATED_LOCALES */
 import React, {
   useState,
   useEffect,
@@ -6,7 +7,6 @@ import React, {
 import PropTypes from 'prop-types';
 import AppSettingsContext from './_AppSettingsContext';
 import { settingsConfigPropType } from '../site/siteConfigPropTypes';
-/* global TERRA_AGGREGATED_LOCALES */
 
 const propTypes = {
   children: PropTypes.element.isRequired,
@@ -20,6 +20,11 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
     defaultDirection = 'ltr',
     themes,
   } = settingsConfig;
+
+  if (Array.isArray(settingsConfig.locales) && settingsConfig.locales.length !== 0) {
+    // eslint-disable-next-line no-console
+    console.warn('Locale configurations are deprecated as of terra-toolkit v5.21.0. You may remove this setting from your configuration files.');
+  }
 
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);
   const [currentDirection, setCurrentDirection] = useState(defaultDirection);
@@ -59,7 +64,6 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       }
     };
 
-    // Use default locales or fall back on user configurations
     const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
 
     return ({

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -21,9 +21,6 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
     themes,
   } = settingsConfig;
 
-  // Use default locales or fall back on user configurations
-  const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
-
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);
   const [currentDirection, setCurrentDirection] = useState(defaultDirection);
   const [currentTheme, setCurrentTheme] = useState(defaultTheme);
@@ -62,6 +59,9 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       }
     };
 
+    // Use default locales or fall back on user configurations
+    const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
+
     return ({
       ...settingsConfig,
       locales,
@@ -71,7 +71,7 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       currentThemeName: themes[currentTheme],
       onUpdate,
     });
-  }, [settingsConfig, locales, themes, currentLocale, currentTheme, currentDirection]);
+  }, [settingsConfig, themes, currentLocale, currentTheme, currentDirection]);
 
   return (
     <AppSettingsContext.Provider value={appSettings}>

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -20,6 +20,15 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
     themes,
   } = settingsConfig;
 
+  /* eslint-disable no-undef, no-console, no-param-reassign */
+  if (TERRA_AGGREGATED_LOCALES) {
+    if (settingsConfig.locales) {
+      console.warn('Locale configurations are deprecated as of terra-toolkit v5.21.0.');
+    }
+    settingsConfig.locales = TERRA_AGGREGATED_LOCALES;
+  }
+  /* eslint-enable */
+
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);
   const [currentDirection, setCurrentDirection] = useState(defaultDirection);
   const [currentTheme, setCurrentTheme] = useState(defaultTheme);

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -64,7 +64,7 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
       }
     };
 
-    /* Use default locales or fall back on default. terra-toolkit v5.21.0 provides configurations from terraI18n, 
+    /* Use default locales or fall back on default. terra-toolkit v5.21.0 provides configurations from terraI18n,
      * so this reduces the number of places users need to define their locales.
      */
     const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : ['en'];

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -23,7 +23,7 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
 
   if (Array.isArray(settingsConfig.locales) && settingsConfig.locales.length !== 0) {
     // eslint-disable-next-line no-console
-    console.warn('Locale configurations are deprecated as of terra-toolkit v5.21.0. You may remove this setting from your configuration files.');
+    console.warn('Locale configurations are deprecated as of terra-dev-site v6.22.0. You may remove this setting from your configuration files.');
   }
 
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);

--- a/src/navigation/_AppSettingsProvider.jsx
+++ b/src/navigation/_AppSettingsProvider.jsx
@@ -6,6 +6,7 @@ import React, {
 import PropTypes from 'prop-types';
 import AppSettingsContext from './_AppSettingsContext';
 import { settingsConfigPropType } from '../site/siteConfigPropTypes';
+/* global TERRA_AGGREGATED_LOCALES */
 
 const propTypes = {
   children: PropTypes.element.isRequired,
@@ -20,14 +21,8 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
     themes,
   } = settingsConfig;
 
-  /* eslint-disable no-undef, no-console, no-param-reassign */
-  if (TERRA_AGGREGATED_LOCALES) {
-    if (settingsConfig.locales) {
-      console.warn('Locale configurations are deprecated as of terra-toolkit v5.21.0.');
-    }
-    settingsConfig.locales = TERRA_AGGREGATED_LOCALES;
-  }
-  /* eslint-enable */
+  // Use default locales or fall back on user configurations
+  const locales = typeof TERRA_AGGREGATED_LOCALES === 'object' ? TERRA_AGGREGATED_LOCALES : settingsConfig.locales;
 
   const [currentLocale, setCurrentLocale] = useState(defaultLocale);
   const [currentDirection, setCurrentDirection] = useState(defaultDirection);
@@ -69,13 +64,14 @@ const AppSettingsProvider = ({ settingsConfig, children }) => {
 
     return ({
       ...settingsConfig,
+      locales,
       currentLocale,
       currentTheme,
       currentDirection,
       currentThemeName: themes[currentTheme],
       onUpdate,
     });
-  }, [settingsConfig, themes, currentLocale, currentTheme, currentDirection]);
+  }, [settingsConfig, locales, themes, currentLocale, currentTheme, currentDirection]);
 
   return (
     <AppSettingsContext.Provider value={appSettings}>

--- a/src/navigation/_SettingsPicker.jsx
+++ b/src/navigation/_SettingsPicker.jsx
@@ -67,7 +67,7 @@ const SettingsPicker = ({ config }) => {
       fill
     >
       <Spacer padding="medium">
-        {config.locales.length > 1 ? (
+        {appSettings.locales.length > 1 ? (
           <SelectField
             label="Locale"
             selectId="terra-dev-site-locale-select"
@@ -80,7 +80,7 @@ const SettingsPicker = ({ config }) => {
               });
             }}
           >
-            {config.locales.map(value => (
+            {appSettings.locales.map(value => (
               <SelectField.Option value={value} display={value} key={value} />
             ))}
           </SelectField>


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Currently projects using terra-dev-site are required to define which locales they use in two different places: `terraI18n.config.js` and `site.config.js`. This update allows terra-dev-site to read locale configurations directly from `terraI18n.config.js`. Terra-dev-site will fall back on defaults if locale configs are not found.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #151

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
I used the orion-application repo as a testing environment for this change using the following steps:

1. changed the `terra-dev-site` dependency from `^6.0.0` to `cerner/terra-dev-site#reduce-locale-definition` in `packages.json`.
2. Commented out lines 2 and 7 in site.config.js.
3. Reduced the number of locales defined in `terraI18n.config.js` (so that they would differ from the defaults).
3. Ran `npm install` and `npm start`.
4. The site's settings menu only showed the locales defined in step 3. 
5. Comment out the locale definitions in `terraI18n.config.js`.
6. Relaunched the site using `npm start`.
7. The site's settings menu showed the default locales.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
