### PR TITLE
Fixes NewRelic error when SessionStorage property of window is not accessible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed failed to read sessionStorage Property error when the access is denied.
+
 ### Changed
 * Updated terra-form-select dependency to ^6.0.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,3 +39,4 @@ Cerner Corporation
 [@lokesh-0813]: https://github.com/lokesh-0813
 [@gabeparra01]: https://github.com/gabeparra01
 [@DMcginn]: https://github.com/DMcginn
+[@ShettyAkarsh] : https://github.com/ShettyAkarsh

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -6,6 +6,12 @@
 // returning a 404 page that stores the requested path and redirects to index.html
 // to allow the SPA router to handle the route.
 // Store the not found window location in session storage
-window.sessionStorage.redirect = window.location.href;
+
+import getSessionStorage from './session';
+
+if (getSessionStorage() !== undefined) {
+  window.sessionStorage.redirect = window.location.href;
+}
+
 // Redirect to the base path. Once done react router will use the stored location to route SPA style.
 window.location.pathname = `${TERRA_DEV_SITE_BASENAME}/`;

--- a/src/rewriteHistory.js
+++ b/src/rewriteHistory.js
@@ -1,11 +1,17 @@
 // This file works in concert with the gh-pages 404 redirect SPA strategy.
 // This file should be included in head.
 // Read href stored by redirect.js from the 404.html page.
-const { redirect } = window.sessionStorage;
-delete sessionStorage.redirect;
 
-// If we have a href and it is not the current location...
-if (redirect && redirect !== window.location.href) {
+import getSessionStorage from './session';
+
+if (getSessionStorage() !== undefined) {
+  const { redirect } = window.sessionStorage;
+
+  delete sessionStorage.redirect;
+
+  // If we have a href and it is not the current location...
+  if (redirect && redirect !== window.location.href) {
   // Replace the current history state with the intended href location.
-  window.history.replaceState(null, null, redirect);
+    window.history.replaceState(null, null, redirect);
+  }
 }

--- a/src/session.js
+++ b/src/session.js
@@ -1,0 +1,14 @@
+// Function to check if sessionStorage property is readable.
+function getSessionStorage() {
+  try {
+    return window.sessionStorage;
+  } catch (e) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.error(e.message);
+    }
+    return undefined;
+  }
+}
+
+export default getSessionStorage;

--- a/src/site/_Site.jsx
+++ b/src/site/_Site.jsx
@@ -13,6 +13,7 @@ import siteConfigPropType from './siteConfigPropTypes';
 import TerraMdxProvider from '../mdx/_TerraMdxProvider';
 
 import './site.module.scss';
+import getSessionStorage from '../session';
 
 const propTypes = {
   /**
@@ -50,7 +51,9 @@ class Site extends React.Component {
    */
   redirectToReservedRoute({ match }) {
     const { siteConfig } = this.props;
-    window.sessionStorage.redirect = window.location.href;
+    if (getSessionStorage() !== undefined) {
+      window.sessionStorage.redirect = window.location.href;
+    }
     window.location.pathname = `${siteConfig.basename}${match.url}/`;
     return null;
   }


### PR DESCRIPTION
### Summary
When cookies are blocked using the browser settings for the sites consuming dev-site. there is a error getting logged in new relic 'Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document'. 

This is mainly because of the sessionStorage property of Window object will not be accessible due to the above settings. this fix will ensure whether the sessionStorage property is accessible before retrieving any values from it and writing into it.


Closes #268 

Thank you for contributing to Terra.
@cerner/terra
