### PR TITLE
[terra-dev-site] Expose status-overlay-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
-* Fixed
-  * Fixed propsTable to have unique selector for styles
+* Changed
+  * Expose status overlay provider from terra-application.
 
 * Fixed
+  * Fixed propsTable to have unique selector for styles
   * Fixed unique id generation and initial mount focus.
   * Update Changelog Formatting
 

--- a/src/navigation/_SecondaryNavigationLayout.jsx
+++ b/src/navigation/_SecondaryNavigationLayout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { withActiveBreakpoint } from 'terra-application/lib/breakpoints';
 import { ApplicationLoadingOverlayProvider } from 'terra-application/lib/application-loading-overlay';
+import { ApplicationStatusOverlayProvider } from 'terra-application/lib/application-status-overlay';
 import ContentContainer from 'terra-content-container';
 
 import ComponentToolbar from './_ComponentToolbar';
@@ -249,7 +250,9 @@ class SecondaryNavigationLayout extends React.Component {
           fill
         >
           <ApplicationLoadingOverlayProvider>
-            {children}
+            <ApplicationStatusOverlayProvider>
+              {children}
+            </ApplicationStatusOverlayProvider>
           </ApplicationLoadingOverlayProvider>
         </ContentContainer>
       </div>


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Exposing status-overlay-provider from terra-application to keep it consistent with loading-overlay.
By exposing status-overlay-provider, it prevents status-overlay from overlapping the terra-dev-site side panel.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->