### PR TITLE
[terra-dev-site-v7] Remove pages config and hotReloading option from site config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * Update minimum node version to node 10.
   * Update react-docgen to ^5.3.0. This is a breaking change as react-docgen only supports node 8.10 and up.
   * Use MDX instead of Marked to load markdown files.
+  * Remove `pagesConfig` option from site config. This was never used by consumers.
+  * Remove `hotReloading` option from site config. There is no reason to disable it through terra dev site config.
 
 ## 6.30.0 - (September 11, 2020)
 

--- a/config/site/site.config.js
+++ b/config/site/site.config.js
@@ -9,11 +9,7 @@ const siteConfig = {
   /* The navigation configuration. */
   navConfig,
 
-  /* The path to the pages configuration. If this is enabled, the `generatePages` configuration will not be used. */
-  pagesConfig: undefined,
-
-  /** These options are used to find the pages to serve via terra-dev-site. If 'pagesConfig' is provided, this
-   * configuration is not used.
+  /** These options are used to find the pages to serve via terra-dev-site.
    * The file extensions pulled in are 'md' extensions and any extension defined in the resolve extensions set in the webpack config.
    *   The search pattern key options:
    *      root: where the search pattern starts.
@@ -32,11 +28,6 @@ const siteConfig = {
       },
     ],
   },
-
-  /** Whether or not hot reloading section should be enabled. This applies to the search searchPatterns
-   * and mono-repo package aliasing. This is enabled by default for dev builds.
-   */
-  hotReloading: true,
 
   /** The root-level npm package.json file. Change this if you have a non-standard package.json path.
    * Defaults to the <root_dir>/package.json

--- a/config/webpack/terra-dev-site.webpack.config.js
+++ b/config/webpack/terra-dev-site.webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const loadSiteConfig = require('../../scripts/generate-app-config/loadSiteConfig');
 const TerraDevSite = require('./plugin/TerraDevSite');
 const TerraDevSiteEntrypoints = require('./plugin/TerraDevSiteEntrypoints');
 const DirectorySwitcherPlugin = require('./plugin/resolve/DirectorySwitcherPlugin');
@@ -12,12 +11,6 @@ const devSiteConfig = (env = {}, argv = {}) => {
   const production = argv.p;
   const processPath = process.cwd();
 
-  // Load the site configuration.
-  const siteConfig = loadSiteConfig();
-
-  // Is hot reloading enabled?
-  const { hotReloading } = siteConfig;
-
   return {
     entry: TerraDevSiteEntrypoints,
     plugins: [
@@ -26,7 +19,7 @@ const devSiteConfig = (env = {}, argv = {}) => {
     resolve: {
       plugins: [
         new DirectorySwitcherPlugin({
-          shouldSwitch: hotReloading && !production,
+          shouldSwitch: !production,
           rootDirectories: [
             processPath,
             path.resolve(processPath, 'packages', '*'),

--- a/scripts/generate-app-config/generatePagesConfig.js
+++ b/scripts/generate-app-config/generatePagesConfig.js
@@ -129,12 +129,8 @@ const sortPageConfig = config => (
 */
 const generatePagesConfig = (siteConfig, resolveExtensions, mode, verbose) => {
   const {
-    generatePages: generatePagesOptions, pagesConfig, navConfig, hotReloading,
+    generatePages: generatePagesOptions, navConfig,
   } = siteConfig;
-  // If a pages config is supplied don't do this logic.
-  if (pagesConfig) {
-    return pagesConfig;
-  }
 
   // Gather the types to search for.
   const types = pageTypes(navConfig).join(',');
@@ -152,7 +148,7 @@ const generatePagesConfig = (siteConfig, resolveExtensions, mode, verbose) => {
     const rootPath = root.replace(/[\\]/g, '/');
     let sourceDir = '';
     if (dist) {
-      sourceDir = (mode !== 'production' && hotReloading && source) ? `${source}/` : `${dist}/`;
+      sourceDir = (mode !== 'production' && source) ? `${source}/` : `${dist}/`;
     }
     acc.push({
       pattern: `${rootPath}/${sourceDir}${entryPoint}/**/*.{${types},}.{${ext.join(',')}}`,

--- a/src/terra-dev-site/tool/terra-dev-site/SiteConfig.b/page.config.c.tool.mdx
+++ b/src/terra-dev-site/tool/terra-dev-site/SiteConfig.b/page.config.c.tool.mdx
@@ -10,17 +10,6 @@ Terra-dev-site uses the pages configuration to recursively build the menu naviga
 
 When you start the site, the `generateAppConfig` script will use these to build the pages.
 
-## Custom Page Config
-
-If you need or want custom page config, you can provide your own by including the `pagesConfig` key in the site config. Below is an example page config. The config is sorted by `Pagetype` such that each page type key is an ordered arrays of page configurations.
-
-This page configuration must provide the `name`, and `path` keys. These keys are needed to successfully create the navigation and routes. Then use the following keys to add meaningful content:
-- `content` - the content to render at this route
-- `type` - the file type. Options include but are not limited to `js`, `jsx`, or `md`
-- `pages` - an array of pages configuration objects for nested navigation
-
-Terra-dev-site will create sub-navigation for any component configuration using the `pages` key and will add a default Placeholder to render at that route.
-
 #### Component API Example
 ```
   'get-started': {


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Remove `pagesConfig` option from site config. This was never used by consumers and frankly would have been very hard to use.

Remove `hotReloading` option from site config. There is no reason to disable it through terra dev site config. You could still disable it by directly using the `DirectorySwitcherPlugin` which is the only thing in terra-dev-site that has anything to do with hot reloading.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Related to: #294

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
