### PR TITLE
[terra-dev-site-v7] Support webpack 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added
   * Added new file `browserslistrc` for Browserslist.
+  * Added support for webpack 5.
 
 * Breaking
   * Remove the ability to include test evidence, this is covered now by a separate site report.

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@mdx-js/mdx": "^1.5.0",
     "@mdx-js/react": "^1.4.5",
     "classnames": "^2.2.5",
-    "enhanced-resolve": "^4.1.0",
+    "enhanced-resolve": "^4.1.0 || ^5.4.0",
     "fuse.js": "^6.4.3",
     "glob": "^7.1.1",
     "html-webpack-plugin": "^4.5.0",
@@ -135,7 +135,7 @@
     "@cerner/terra-application": "cerner/terra-application#30f1e0a57f93ba119f08d4b95edd8ae4d597a866",
     "react-dom": "^16.8.5",
     "react": "^16.8.5",
-    "webpack": "^4.28.1"
+    "webpack": "^4.44.2 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/src/webpack/loaders/devSiteExample.js
+++ b/src/webpack/loaders/devSiteExample.js
@@ -22,7 +22,7 @@ const loader = async function loader(content) {
 
   if (cssFileName !== undefined) {
     try {
-      this.resolve('', cssFileName, async () => {
+      this.resolve(this.context, cssFileName, async () => {
       });
       code.push(`import Css from '${cssFileName}?dev-site-codeblock';`,
         `export default ({ title, description, isExpanded }) => (

--- a/src/webpack/plugin/SitePlugin.js
+++ b/src/webpack/plugin/SitePlugin.js
@@ -220,7 +220,7 @@ class SitePlugin {
   }
 
   apply(compiler) {
-    const isWebpack5 = compiler.webpack.version.startsWith('5');
+    const isWebpack5 = compiler.webpack && compiler.webpack.version.startsWith('5');
 
     // Use default public path else the env else /
     let defaultPublicPath;

--- a/src/webpack/plugin/SitePlugin.js
+++ b/src/webpack/plugin/SitePlugin.js
@@ -59,128 +59,145 @@ class SitePlugin {
     sourceFolder,
     distributionFolder,
     basename,
+    isWebpack5,
   }) {
     if (oneTimeSetupComplete) {
       return;
     }
     oneTimeSetupComplete = true;
-
-    compiler.options.entry = {
-      ...compiler.options.entry,
-      rewriteHistory: '@cerner/terra-dev-site/lib/browser-router-redirect/rewriteHistory',
-      redirect: '@cerner/terra-dev-site/lib/browser-router-redirect/redirect',
-    };
-
-    // MODULE
     const mdxLoader = getMdxLoader(compiler.options.output.publicPath);
-    compiler.options.module.rules = [{
-      // Drop loaders in a 'one of' block to avoid the original loaders applying on top of the new loaders.
-      // Only the first loader will apply and no others.
-      oneOf: [{
-        test: /\.mdx$/,
-        use: [
-          babelLoader,
-          mdxLoader,
-        ],
-      }, {
-        test: /\.md$/,
-        oneOf: [
-          {
-            // Use MDX to import any md files imported from an mdx file.
-            issuer: [
-              /\.mdx?$/,
-              /entry\.template$/,
-            ],
-            use: [
-              babelLoader,
-              mdxLoader,
-            ],
-          },
-          {
-            use: 'raw-loader',
-          },
-        ],
-      }, {
-        resourceQuery: '?dev-site-codeblock',
-        // this bypasses the default json loader
-        type: 'javascript/auto',
-        use: [
-          babelLoader,
-          mdxLoader,
-          {
-            loader: 'devSiteCodeblock',
-            options: {
-              resolveExtensions: compiler.options.resolve.extensions,
-            },
-          },
-        ],
-      }, {
-        resourceQuery: '?dev-site-example',
-        use: [
-          babelLoader,
-          'devSiteExample',
-        ],
-      }, {
-        test: /\.json$/,
-        // this bypasses the default json loader
-        type: 'javascript/auto',
-        resourceQuery: '?dev-site-package',
-        use: [
-          babelLoader,
-          'devSitePackage',
-        ],
-      }, {
-        resourceQuery: '?dev-site-props-table',
-        use: [
-          babelLoader,
-          {
-            loader: 'devSitePropsTable',
-            options: {
-              mdx: mdxOptions(compiler.options.output.publicPath),
-              resolveExtensions: compiler.options.resolve.extensions,
-            },
-          },
-        ],
-      },
-      // Spread the original loaders. These will be applied if all above loaders fail.
-      ...compiler.options.module.rules,
-      ],
-    }];
-
-    // RESOLVE
-    // If plugins is not defined, define it.
-    if (!compiler.options.resolve.plugins) {
-      compiler.options.resolve.plugins = [];
-    }
 
     // If a mono repo, update the rootDirectories to include all the packages.
     const rootDirectories = [
       ...isLernaMonoRepo ? [path.resolve(processPath, 'packages', '*')] : [processPath],
     ];
 
-    // Switch between source and distribution files.
-    compiler.options.resolve.plugins.push(
-      new DirectorySwitcherPlugin({
-        shouldSwitch: compiler.options.mode !== 'production',
-        source: sourceFolder,
-        distribution: distributionFolder,
-        rootDirectories,
-      }),
-    );
+    let webpackConfig = {
+      entry: {
+        rewriteHistory: '@cerner/terra-dev-site/lib/browser-router-redirect/rewriteHistory',
+        redirect: '@cerner/terra-dev-site/lib/browser-router-redirect/redirect',
+      },
+      module: {
+        rules: [{
+          // Drop loaders in a 'one of' block to avoid the original loaders applying on top of the new loaders.
+          // Only the first loader will apply and no others.
+          oneOf: [{
+            test: /\.mdx$/,
+            use: [
+              babelLoader,
+              mdxLoader,
+            ],
+          }, {
+            test: /\.md$/,
+            oneOf: [
+              {
+                // Use MDX to import any md files imported from an mdx file.
+                issuer: [
+                  /\.mdx?$/,
+                  /entry\.template$/,
+                ],
+                use: [
+                  babelLoader,
+                  mdxLoader,
+                ],
+              },
+              {
+                use: 'raw-loader',
+              },
+            ],
+          }, {
+            resourceQuery: '?dev-site-codeblock',
+            // this bypasses the default json loader
+            type: 'javascript/auto',
+            use: [
+              babelLoader,
+              mdxLoader,
+              {
+                loader: 'devSiteCodeblock',
+                options: {
+                  resolveExtensions: compiler.options.resolve.extensions,
+                },
+              },
+            ],
+          }, {
+            resourceQuery: '?dev-site-example',
+            use: [
+              babelLoader,
+              'devSiteExample',
+            ],
+          }, {
+            test: /\.json$/,
+            // this bypasses the default json loader
+            type: 'javascript/auto',
+            resourceQuery: '?dev-site-package',
+            use: [
+              babelLoader,
+              'devSitePackage',
+            ],
+          }, {
+            resourceQuery: '?dev-site-props-table',
+            use: [
+              babelLoader,
+              {
+                loader: 'devSitePropsTable',
+                options: {
+                  mdx: mdxOptions(compiler.options.output.publicPath),
+                  resolveExtensions: compiler.options.resolve.extensions,
+                },
+              },
+            ],
+          },
+          ],
+        }],
+      },
+      resolve: {
+        plugins: [
+          // Switch between source and distribution files.
+          new DirectorySwitcherPlugin({
+            shouldSwitch: compiler.options.mode !== 'production',
+            source: sourceFolder,
+            distribution: distributionFolder,
+            rootDirectories,
+          }),
+          // Alias the local package to allow imports to reference the file as if it was imported from node modules.
+          new LocalPackageAliasPlugin({
+            rootDirectories,
+          }),
+        ],
+      },
+      // add the path to search for dev site loaders
+      resolveLoader: {
+        modules: [
+          path.resolve(__dirname, '..', 'loaders'),
+          'node_modules',
+        ],
+      },
+      devServer: {
+        // Setting this to enable browser routing
+        historyApiFallback: true,
+      },
+    };
 
-    // Alias the local package to allow imports to reference the file as if it was imported from node modules.
-    compiler.options.resolve.plugins.push(
-      new LocalPackageAliasPlugin({
-        rootDirectories,
-      }),
-    );
+    // If this plugin is used with webpack 5 we must normalize the webpack config.
+    if (isWebpack5) {
+      webpackConfig = compiler.webpack.config.getNormalizedWebpackOptions(webpackConfig);
+    }
+
+    // ENTRY
+    compiler.options.entry = {
+      ...compiler.options.entry,
+      ...webpackConfig.entry,
+    };
+
+    // MODULE
+    webpackConfig.module.rules[0].oneOf = webpackConfig.module.rules[0].oneOf.concat(compiler.options.module.rules);
+    compiler.options.module.rules = webpackConfig.module.rules;
+
+    // RESOLVE
+    compiler.options.resolve.plugins = (compiler.options.resolve.plugins || []).concat(webpackConfig.resolve.plugins);
 
     // RESOLVE LOADER
-    // add the path to search for dev site loaders
-    compiler.options.resolveLoader.modules = [
-      path.resolve(__dirname, '..', 'loaders'),
-      'node_modules',
-    ];
+    compiler.options.resolveLoader.modules = webpackConfig.resolveLoader.modules;
 
     // generate the 404 page.
     new HtmlWebpackPlugin({
@@ -193,7 +210,7 @@ class SitePlugin {
     // WEBPACK DEV SERVER
     if (compiler.options.devServer) {
       // Setting this to enable browser routing
-      compiler.options.devServer.historyApiFallback = true;
+      compiler.options.devServer.historyApiFallback = webpackConfig.devServer.historyApiFallback;
     }
 
     new DefinePlugin({
@@ -203,6 +220,8 @@ class SitePlugin {
   }
 
   apply(compiler) {
+    const isWebpack5 = compiler.webpack.version.startsWith('5');
+
     // Use default public path else the env else /
     let defaultPublicPath;
     if (compiler.options.output && compiler.options.output.publicPath) {
@@ -224,13 +243,8 @@ class SitePlugin {
       sourceFolder,
       distributionFolder,
       basename,
+      isWebpack5,
     });
-
-    // ENTRY
-    compiler.options.entry = {
-      ...compiler.options.entry,
-      [this.entryKey]: `@cerner/terra-dev-site/lib/webpack/templates/entry.template${this.resourceQuery}`,
-    };
 
     // Get the list of apps excluding this current app.
     const filteredSites = Object.values(siteRegistry).filter(site => site.path !== this.siteConfig.pathPrefix);
@@ -247,27 +261,49 @@ class SitePlugin {
       basename = [basename, this.siteConfig.pathPrefix].join('/');
     }
 
+    let webpackConfig = {
+      entry: {
+        [this.entryKey]: `@cerner/terra-dev-site/lib/webpack/templates/entry.template${this.resourceQuery}`,
+      },
+      module: {
+        rules: [
+          {
+            // This loader generates the entrypoint and sets up the config template path and resource query.
+            resourceQuery: this.resourceQuery,
+            use: [
+              babelLoader,
+              {
+                loader: 'devSiteEntry',
+                options: {
+                  entryPath: this.entry,
+                  siteConfig: this.siteConfig,
+                  sites: otherSites,
+                  basename,
+                  resolveExtensions: compiler.options.resolve.extensions,
+                  isLernaMonoRepo,
+                  contentDirectory: this.contentDirectory,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    // If this plugin is used with webpack 5 we must normalize the webpack config.
+    if (isWebpack5) {
+      webpackConfig = compiler.webpack.config.getNormalizedWebpackOptions(webpackConfig);
+    }
+
+    // ENTRY
+    compiler.options.entry = {
+      ...compiler.options.entry,
+      ...webpackConfig.entry,
+    };
+
     // MODULE
     // we know there is a oneOf here because we just added it.
-    compiler.options.module.rules[0].oneOf.unshift({
-      // This loader generates the entrypoint and sets up the config template path and resource query.
-      resourceQuery: this.resourceQuery,
-      use: [
-        babelLoader,
-        {
-          loader: 'devSiteEntry',
-          options: {
-            entryPath: this.entry,
-            siteConfig: this.siteConfig,
-            sites: otherSites,
-            basename,
-            resolveExtensions: compiler.options.resolve.extensions,
-            isLernaMonoRepo,
-            contentDirectory: this.contentDirectory,
-          },
-        },
-      ],
-    });
+    compiler.options.module.rules[0].oneOf.unshift(webpackConfig.module.rules[0]);
 
     // Generate the index.html file for the site.
     new HtmlWebpackPlugin({


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

This PR updates terra-dev-site v7 to support both webpack 4 and 5. With this PR we're not updating to use webpack 5, but just support it.

Primarily webpack 5 has a different options structure and the plugin has been reworked to passively support it.

This branch is also validated in terra toolkit here: https://github.com/cerner/terra-toolkit/pull/495

I will be putting out a validation branch that uses the un-released webpack-config-terra webpack 5 package to upgrade this package to webpack 5 to demonstrate that it works.

Edit: validation PR: #322

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
