### PR TITLE
[terra-dev-site-v7] Fix scoped package namespaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Set default code owners for all files in repo
-* @emilyrohrbough @mjhenkes @ryanthemanuel @tbiethman @dkasper-was-taken @StephenEsser
+* @mjhenkes @ryanthemanuel @tbiethman @dkasper-was-taken

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "terra-status-view": "^4.1.0"
   },
   "peerDependencies": {
-    "@cerner/terra-application": "cerner/terra-application#54cd83b4aa3511d316005fdb36d2040bc684d07b",
+    "@cerner/terra-application": "cerner/terra-application#869470a0cc93cb4eb4e3494ebe543c4405441ca4",
     "react-dom": "^16.8.5",
     "react": "^16.8.5",
     "webpack": "^4.44.2 || ^5.0.0"
@@ -120,7 +120,7 @@
     "@cerner/eslint-config-terra": "^5.0.0",
     "@cerner/jest-config-terra": "^1.0.0",
     "@cerner/stylelint-config-terra": "^4.0.0",
-    "@cerner/terra-application": "cerner/terra-application#54cd83b4aa3511d316005fdb36d2040bc684d07b",
+    "@cerner/terra-application": "cerner/terra-application#869470a0cc93cb4eb4e3494ebe543c4405441ca4",
     "@cerner/terra-cli": "^1.1.0",
     "@cerner/terra-functional-testing": "^1.0.1",
     "@cerner/terra-open-source-scripts": "^1.1.0",

--- a/src/webpack/loaderUtils/configHelpers.js
+++ b/src/webpack/loaderUtils/configHelpers.js
@@ -25,7 +25,6 @@ const pageTypes = primaryNavigationItems => (primaryNavigationItems.reduce((acc,
 const getNamespace = (directory, namespace) => {
   // If this is a monorepo package, we need to pull the namespace from the package.json file to account for scoping.
   const packageRoot = (/.*packages\/[^/]*/.exec(directory) || {})[0];
-  console.log('packageRoot', packageRoot);
   let afterPackages;
   if (packageRoot) {
     const packagePath = path.join(packageRoot, 'package.json');

--- a/src/webpack/loaderUtils/configHelpers.js
+++ b/src/webpack/loaderUtils/configHelpers.js
@@ -1,5 +1,8 @@
 const path = require('path');
+const fs = require('fs');
 const lodashStartCase = require('lodash.startcase');
+
+const monoRepoPackageCache = {};
 
 /**
  * Cheat. If the filename still contains a period, don't run startcase. This allows for filenames of version (v0.5.0).
@@ -20,8 +23,22 @@ const pageTypes = primaryNavigationItems => (primaryNavigationItems.reduce((acc,
  * Provides the namespace for the package in this order, mono repo package, node_modules package, provided package name.
  */
 const getNamespace = (directory, namespace) => {
-  const afterPackages = (/packages\/([^/]*)/.exec(directory) || {})[1];
-  const afterNodeModules = (/node_modules\/([^/]*)/.exec(directory) || {})[1];
+  // If this is a monorepo package, we need to pull the namespace from the package.json file to account for scoping.
+  const packageRoot = (/.*packages\/[^/]*/.exec(directory) || {})[0];
+  console.log('packageRoot', packageRoot);
+  let afterPackages;
+  if (packageRoot) {
+    const packagePath = path.join(packageRoot, 'package.json');
+    // cache the package name to avoid opening the files all the time.
+    afterPackages = monoRepoPackageCache[packagePath];
+    if (!afterPackages && fs.existsSync(packagePath)) {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      afterPackages = require(packagePath).name;
+      monoRepoPackageCache[packagePath] = afterPackages;
+    }
+  }
+  // Find the directory name directly after node modules... include scoped package if they exist.
+  const afterNodeModules = (/node_modules\/((@[^/]*\/)?[^/]*)/.exec(directory) || {})[1];
 
   return afterPackages || afterNodeModules || namespace;
 };

--- a/tests/jest/webpack/loaderUtils/configHelpers.test.js
+++ b/tests/jest/webpack/loaderUtils/configHelpers.test.js
@@ -1,0 +1,36 @@
+const path = require('path');
+
+const configHelpers = require('../../../../src/webpack/loaderUtils/configHelpers');
+
+describe('getNamespace', () => {
+  it('returns the namespace when the directory does not include packages or node_modules', () => {
+    const directory = '/directory/';
+    const namespace = 'namespace';
+    const result = configHelpers.getNamespace(directory, namespace);
+    expect(result).toEqual(namespace);
+  });
+
+  it('returns the package name immediately following the node_module directory', () => {
+    const directory = '/node_modules/directory/';
+    const namespace = 'namespace';
+    const result = configHelpers.getNamespace(directory, namespace);
+    expect(result).toEqual('directory');
+  });
+
+  it('returns the scoped package name immediately following the node_module directory', () => {
+    const directory = '/node_modules/@cerner/directory/';
+    const namespace = 'namespace';
+    const result = configHelpers.getNamespace(directory, namespace);
+    expect(result).toEqual('@cerner/directory');
+  });
+
+  it('returns the package name from the package.json associated with the mono repo package.', () => {
+    const directory = path.resolve(process.cwd(), 'tests', 'jest', 'webpack', 'loaderUtils', 'testContent', 'packages', 'module', 'file');
+    const namespace = 'namespace';
+    let result = configHelpers.getNamespace(directory, namespace);
+    expect(result).toEqual('@cerner/testing');
+
+    result = configHelpers.getNamespace(directory, namespace);
+    expect(result).toEqual('@cerner/testing');
+  });
+});

--- a/tests/jest/webpack/loaderUtils/testContent/packages/module/package.json
+++ b/tests/jest/webpack/loaderUtils/testContent/packages/module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@cerner/testing"
+
+}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Scoped packages were not getting the correct url namespace.

There are two cases where we want to namespace documentation in a url, if it's coming from node modules or if it's coming from the packages directory. Neither case was correctly handing scoped modules.

#### node modules

For node modules this we had assumed the namespace for a package was just the first directory after the node_modules directory. This is incorrect in the case of scoped packages. Now we will grab the first and second directories in when an @ scoped directory is found.

```diff
- https://engineering.cerner.com/terra-ui/dev_tools/cerner/browserslist-config-terra/upgrade-guide
+ https://engineering.cerner.com/terra-ui/dev_tools/cerner-terra-toolkit-docs/browserslist-config-terra/upgrade-guide
```

#### mono repo packages

The scoped mono repo packages do not have the scoped name in their directory structure so to correctly pull the scoped name we have to read the package.json name.

```diff
- https://engineering.cerner.com/terra-toolkit/dev_tools/terra-toolkit-docs/browserslist-config-terra/upgrade-guide
+ https://engineering.cerner.com/terra-toolkit/dev_tools/cerner-terra-toolkit-docs/browserslist-config-terra/upgrade-guide
```
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
