### PR TITLE
Added browser to resolve.mainFields to support modern syntax for older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `browser` to `resolve.mainFields` to support modern syntax for older browsers.
+
 ## 6.37.0 - (June 23, 2021)
 
 * Fixed

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -149,7 +149,7 @@ const webpackConfig = (options, env, argv) => {
     resolve: {
       extensions: ['.js', '.jsx'],
       modules: resolveModules,
-      mainFields: ['main'],
+      mainFields: ['browser', 'main'],
     },
     output: {
       filename: `${filename}.js`,


### PR DESCRIPTION
### Summary
Add 'browser' to the beginning of mainFields in webpack.config.js so that more modern syntax (e.g. const) used in dependency packages are supported in older browsers (i.e. IE11).

The change on this PR is the same as on https://github.com/cerner/terra-toolkit/pull/536 in webpack-config-terra.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #365 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-dev-site-deployed-pr-45.herokuapp.com/ -->
https://terra-dev-site-deployed-pr-#.herokuapp.com/

### Testing
Got error in orion-application dev-site before change:
<img width="1611" alt="Screen Shot 2021-07-14 at 2 36 31 PM" src="https://user-images.githubusercontent.com/22618655/125693425-9b5002f9-ab44-408a-850d-b3632cd21cb7.png">


No error in orion-application dev-site after change:
<img width="1611" alt="Screen Shot 2021-07-14 at 4 15 59 PM" src="https://user-images.githubusercontent.com/22618655/125694086-d7f808cb-d9f0-4e4b-a41d-3f1e9912d39b.png">


### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
